### PR TITLE
Issue#26 Set AutoScroll on Panels to True

### DIFF
--- a/BookClub/DiscussionBoard.Designer.cs
+++ b/BookClub/DiscussionBoard.Designer.cs
@@ -110,6 +110,7 @@
             // 
             // pnlDiscussionBoard
             // 
+            pnlDiscussionBoard.AutoScroll = true;
             pnlDiscussionBoard.Location = new Point(174, 95);
             pnlDiscussionBoard.Name = "pnlDiscussionBoard";
             pnlDiscussionBoard.Size = new Size(588, 184);

--- a/BookClub/Reviews.Designer.cs
+++ b/BookClub/Reviews.Designer.cs
@@ -140,6 +140,7 @@
             // 
             // pnlReviewBoard
             // 
+            pnlReviewBoard.AutoScroll = true;
             pnlReviewBoard.Location = new Point(171, 96);
             pnlReviewBoard.Name = "pnlReviewBoard";
             pnlReviewBoard.Size = new Size(588, 184);


### PR DESCRIPTION
This pull request includes a small enhancement to the UI components in the `BookClub` application. The changes enable auto-scrolling for specific panels to improve user experience when content exceeds the visible area.

* UI improvements:
  * [`BookClub/DiscussionBoard.Designer.cs`](diffhunk://#diff-3de1543ff34751ff9584cde6a46210efc0bd746859c9c038d85a73a8cc8c9d2fR113): Enabled `AutoScroll` for the `pnlDiscussionBoard` panel.
  * [`BookClub/Reviews.Designer.cs`](diffhunk://#diff-1b48b24fc256b7bfac30d9c76f75cc99d9f5eef908d465caa3a629bffe443918R143): Enabled `AutoScroll` for the `pnlReviewBoard` panel.

Closes #26