### PR TITLE
Issue#41 Add Book Info to Reviews Form

### DIFF
--- a/BookClub/BookList.cs
+++ b/BookClub/BookList.cs
@@ -73,6 +73,15 @@ namespace BookClub
                 btn.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
                 btn.Tag = book.BookId;
                 btn.UseCompatibleTextRendering = true;
+
+                btn.Click += (s, e) =>
+                {
+                    int bookId = (int)((Button)s).Tag;
+                    Reviews reviewsForm = new Reviews(bookId);
+                    reviewsForm.Show();
+                    this.Hide();
+                };
+
                 pnlBookList.Controls.Add(btn);
             }
         }

--- a/BookClub/DiscussionBoard.cs
+++ b/BookClub/DiscussionBoard.cs
@@ -12,10 +12,14 @@ namespace BookClub
 {
     public partial class DiscussionBoard : Form
     {
-        public DiscussionBoard()
+        private int _bookId;
+
+        public DiscussionBoard(int bookId)
         {
             InitializeComponent();
             this.FormClosed += (s, args) => Application.Exit();
+            _bookId = bookId;
+            // Use _bookId to load book-specific discussions or info here
         }
 
         private void btnLogout_Click(object sender, EventArgs e)
@@ -34,7 +38,7 @@ namespace BookClub
 
         private void btnReviews_Click(object sender, EventArgs e)
         {
-            Reviews reviewsForm = new Reviews();
+            Reviews reviewsForm = new Reviews(_bookId);
             reviewsForm.Show();
             this.Hide();
         }

--- a/BookClub/Reviews.Designer.cs
+++ b/BookClub/Reviews.Designer.cs
@@ -172,6 +172,7 @@
             pcbStar3.Location = new Point(449, 369);
             pcbStar3.Name = "pcbStar3";
             pcbStar3.Size = new Size(25, 25);
+            pcbStar3.SizeMode = PictureBoxSizeMode.StretchImage;
             pcbStar3.TabIndex = 14;
             pcbStar3.TabStop = false;
             // 
@@ -180,6 +181,7 @@
             pcbStar2.Location = new Point(418, 369);
             pcbStar2.Name = "pcbStar2";
             pcbStar2.Size = new Size(25, 25);
+            pcbStar2.SizeMode = PictureBoxSizeMode.StretchImage;
             pcbStar2.TabIndex = 15;
             pcbStar2.TabStop = false;
             // 
@@ -188,6 +190,7 @@
             pcbStar4.Location = new Point(480, 369);
             pcbStar4.Name = "pcbStar4";
             pcbStar4.Size = new Size(25, 25);
+            pcbStar4.SizeMode = PictureBoxSizeMode.StretchImage;
             pcbStar4.TabIndex = 16;
             pcbStar4.TabStop = false;
             // 
@@ -196,6 +199,7 @@
             pcbStar1.Location = new Point(385, 369);
             pcbStar1.Name = "pcbStar1";
             pcbStar1.Size = new Size(25, 25);
+            pcbStar1.SizeMode = PictureBoxSizeMode.StretchImage;
             pcbStar1.TabIndex = 17;
             pcbStar1.TabStop = false;
             // 
@@ -204,6 +208,7 @@
             pcbStar5.Location = new Point(511, 369);
             pcbStar5.Name = "pcbStar5";
             pcbStar5.Size = new Size(25, 25);
+            pcbStar5.SizeMode = PictureBoxSizeMode.StretchImage;
             pcbStar5.TabIndex = 18;
             pcbStar5.TabStop = false;
             // 

--- a/BookClub/Reviews.cs
+++ b/BookClub/Reviews.cs
@@ -22,6 +22,7 @@ namespace BookClub
             _bookId = bookId;
 
             this.FormClosed += (s, args) => Application.Exit();
+            LoadBookInfo(_bookId);
 
             stars = new PictureBox[] { pcbStar1, pcbStar2, pcbStar3, pcbStar4, pcbStar5 };
             for (int i = 0; i < stars.Length; i++)
@@ -75,6 +76,36 @@ namespace BookClub
             DiscussionBoard discussionBoardForm = new DiscussionBoard(_bookId);
             discussionBoardForm.Show();
             this.Hide();
+        }
+
+        private void LoadBookInfo(int bookId)
+        {
+            string connectionString = "Server=localhost;Database=BookClub;Trusted_Connection=True;TrustServerCertificate=True;";
+            string query = "SELECT Title, Author, ISBN, BookDescription FROM Books WHERE BookId = @BookId";
+
+            using (var conn = new Microsoft.Data.SqlClient.SqlConnection(connectionString))
+            using (var cmd = new Microsoft.Data.SqlClient.SqlCommand(query, conn))
+            {
+                cmd.Parameters.AddWithValue("@BookId", bookId);
+                conn.Open();
+                using (var reader = cmd.ExecuteReader())
+                {
+                    if (reader.Read())
+                    {
+                        lblBookTitle.Text = reader["Title"].ToString();
+                        lblAuthor.Text = "Author: " + reader["Author"].ToString();
+                        lblISBN.Text = "ISBN: " + reader["ISBN"].ToString();
+                        lblDescription.Text = reader["BookDescription"].ToString();
+                    }
+                    else
+                    {
+                        lblBookTitle.Text = "Book Title";
+                        lblAuthor.Text = "Author";
+                        lblISBN.Text = "ISBN";
+                        lblDescription.Text = "Description";
+                    }
+                }
+            }
         }
     }
 }

--- a/BookClub/Reviews.cs
+++ b/BookClub/Reviews.cs
@@ -14,9 +14,13 @@ namespace BookClub
     {
         private PictureBox[] stars;
         private int currentRating = 0;
-        public Reviews()
+        private int _bookId;
+
+        public Reviews(int bookId)
         {
             InitializeComponent();
+            _bookId = bookId;
+
             this.FormClosed += (s, args) => Application.Exit();
 
             stars = new PictureBox[] { pcbStar1, pcbStar2, pcbStar3, pcbStar4, pcbStar5 };
@@ -68,7 +72,7 @@ namespace BookClub
 
         private void btnOpenDiscussionBoard_Click(object sender, EventArgs e)
         {
-            DiscussionBoard discussionBoardForm = new DiscussionBoard();
+            DiscussionBoard discussionBoardForm = new DiscussionBoard(_bookId);
             discussionBoardForm.Show();
             this.Hide();
         }


### PR DESCRIPTION
This pull request enhances the navigation and data flow between the book list, reviews, and discussion board forms by passing the selected book's ID throughout the application. It also improves the user interface by ensuring star images in the reviews form are displayed correctly. The most significant changes are grouped below:

**Navigation and Data Flow Improvements:**

* Updated the `Reviews` and `DiscussionBoard` forms to accept a `bookId` parameter, ensuring that all book-specific data and navigation actions are tied to the selected book. This includes updating constructors and button click handlers in `BookList.cs`, `DiscussionBoard.cs`, and `Reviews.cs` to pass the correct `bookId` when opening forms. [[1]](diffhunk://#diff-e7d9479458c64506d1d3dbcd383c273e033ebe38d6f6e4b66c402d1a84dd3b2fR76-R84) [[2]](diffhunk://#diff-c419811674e39fa358c17be201001a2b5405c2897e9e4ea853a65019e72cc2fcL15-R22) [[3]](diffhunk://#diff-c419811674e39fa358c17be201001a2b5405c2897e9e4ea853a65019e72cc2fcL37-R41) [[4]](diffhunk://#diff-e411c03cd95fe07cf142cbc39856abf82cfbc47406b9634d991469fbb51f2ee3L17-R25) [[5]](diffhunk://#diff-e411c03cd95fe07cf142cbc39856abf82cfbc47406b9634d991469fbb51f2ee3L71-R109)
* Added a `LoadBookInfo` method in `Reviews.cs` that retrieves and displays the selected book's information from the database based on the `bookId`. [[1]](diffhunk://#diff-e411c03cd95fe07cf142cbc39856abf82cfbc47406b9634d991469fbb51f2ee3L17-R25) [[2]](diffhunk://#diff-e411c03cd95fe07cf142cbc39856abf82cfbc47406b9634d991469fbb51f2ee3L71-R109)

**User Interface Enhancements:**

* Set the `SizeMode` property of all star `PictureBox` controls in the reviews form to `StretchImage`, ensuring that star images are rendered correctly regardless of their size. [[1]](diffhunk://#diff-1b48b24fc256b7bfac30d9c76f75cc99d9f5eef908d465caa3a629bffe443918R175) [[2]](diffhunk://#diff-1b48b24fc256b7bfac30d9c76f75cc99d9f5eef908d465caa3a629bffe443918R184) [[3]](diffhunk://#diff-1b48b24fc256b7bfac30d9c76f75cc99d9f5eef908d465caa3a629bffe443918R193) [[4]](diffhunk://#diff-1b48b24fc256b7bfac30d9c76f75cc99d9f5eef908d465caa3a629bffe443918R202) [[5]](diffhunk://#diff-1b48b24fc256b7bfac30d9c76f75cc99d9f5eef908d465caa3a629bffe443918R211)

Closes #41