### PR TITLE
Rename tables and update migrations for consistency

### DIFF
--- a/BookClub/Migrations/20250829022015_ModelChangeErrorFix.Designer.cs
+++ b/BookClub/Migrations/20250829022015_ModelChangeErrorFix.Designer.cs
@@ -4,6 +4,7 @@ using BookClub.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookClub.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250829022015_ModelChangeErrorFix")]
+    partial class ModelChangeErrorFix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookClub/Migrations/20250829022015_ModelChangeErrorFix.cs
+++ b/BookClub/Migrations/20250829022015_ModelChangeErrorFix.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookClub.Migrations
+{
+    /// <inheritdoc />
+    public partial class ModelChangeErrorFix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_reviews",
+                table: "reviews");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_books",
+                table: "books");
+
+            migrationBuilder.RenameTable(
+                name: "reviews",
+                newName: "Reviews");
+
+            migrationBuilder.RenameTable(
+                name: "books",
+                newName: "Books");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Reviews",
+                table: "Reviews",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Books",
+                table: "Books",
+                column: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Reviews",
+                table: "Reviews");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Books",
+                table: "Books");
+
+            migrationBuilder.RenameTable(
+                name: "Reviews",
+                newName: "reviews");
+
+            migrationBuilder.RenameTable(
+                name: "Books",
+                newName: "books");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_reviews",
+                table: "reviews",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_books",
+                table: "books",
+                column: "Id");
+        }
+    }
+}


### PR DESCRIPTION
Closes #114

Updated Entity Framework Core migration files and model snapshot in the `BookClub` application. Renamed database tables from lowercase (`books` and `reviews`) to PascalCase (`Books` and `Reviews`). Added primary keys for the renamed tables and updated the `BuildTargetModel` method to reflect the new table names, including seed data for `Account`, `Book`, and `Review` entities.