### PR TITLE
#153 implement edit for discussion board

### DIFF
--- a/BookClub/Forms/DiscussionBoard.cs
+++ b/BookClub/Forms/DiscussionBoard.cs
@@ -192,7 +192,12 @@ public partial class DiscussionBoard : Form
 
     private void btnEditPost_Click(object sender, EventArgs e)
     {
-        MessageBox.Show($"Editing comment: {_selectedDiscussion.Comment}");
+        var discussionContext = Program.AppServices.GetRequiredService<DiscussionContext>();
+        discussionContext.CurrentDiscussion = _selectedDiscussion;
+
+        EditDiscussion editDiscussionForm = Program.AppServices.GetRequiredService<EditDiscussion>();
+        editDiscussionForm.Show();
+        this.Hide();
     }
 
     private void btnDeletePost_Click(object sender, EventArgs e)

--- a/BookClub/Forms/EditDiscussion.Designer.cs
+++ b/BookClub/Forms/EditDiscussion.Designer.cs
@@ -1,0 +1,102 @@
+﻿namespace BookClub.Forms
+{
+    partial class EditDiscussion
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            btnBack = new Button();
+            btnLogout = new Button();
+            btnSaveChanges = new Button();
+            txtComment = new TextBox();
+            SuspendLayout();
+            // 
+            // btnBack
+            // 
+            btnBack.Location = new Point(10, 40);
+            btnBack.Margin = new Padding(3, 2, 3, 2);
+            btnBack.Name = "btnBack";
+            btnBack.Size = new Size(114, 27);
+            btnBack.TabIndex = 5;
+            btnBack.Text = "Back";
+            btnBack.UseVisualStyleBackColor = true;
+            btnBack.Click += btnBack_Click;
+            // 
+            // btnLogout
+            // 
+            btnLogout.Location = new Point(10, 9);
+            btnLogout.Margin = new Padding(3, 2, 3, 2);
+            btnLogout.Name = "btnLogout";
+            btnLogout.Size = new Size(114, 27);
+            btnLogout.TabIndex = 4;
+            btnLogout.Text = "Logout";
+            btnLogout.UseVisualStyleBackColor = true;
+            // 
+            // btnSaveChanges
+            // 
+            btnSaveChanges.Location = new Point(270, 242);
+            btnSaveChanges.Margin = new Padding(3, 2, 3, 2);
+            btnSaveChanges.Name = "btnSaveChanges";
+            btnSaveChanges.Size = new Size(156, 37);
+            btnSaveChanges.TabIndex = 20;
+            btnSaveChanges.Text = "Save Changes";
+            btnSaveChanges.UseVisualStyleBackColor = true;
+            btnSaveChanges.Click += btnSaveChanges_Click;
+            // 
+            // txtComment
+            // 
+            txtComment.Location = new Point(142, 104);
+            txtComment.Margin = new Padding(3, 2, 3, 2);
+            txtComment.Multiline = true;
+            txtComment.Name = "txtComment";
+            txtComment.PlaceholderText = "Discussion Comment";
+            txtComment.Size = new Size(425, 120);
+            txtComment.TabIndex = 19;
+            // 
+            // EditDiscussion
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(700, 338);
+            Controls.Add(btnSaveChanges);
+            Controls.Add(txtComment);
+            Controls.Add(btnBack);
+            Controls.Add(btnLogout);
+            Margin = new Padding(3, 2, 3, 2);
+            Name = "EditDiscussion";
+            Text = "Edit Review";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Button btnBack;
+        private Button btnLogout;
+        private Button btnSaveChanges;
+        private TextBox txtComment;
+    }
+}

--- a/BookClub/Forms/EditDiscussion.cs
+++ b/BookClub/Forms/EditDiscussion.cs
@@ -1,0 +1,82 @@
+﻿using BookClub.Models;
+using BookClub.Repositories;
+using BookClub.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Windows.Forms;
+
+namespace BookClub.Forms
+{
+    public partial class EditDiscussion : Form
+    {
+        private readonly DiscussionsRepository _repo;
+        private readonly Discussion? _selectedDiscussion = null;
+        public EditDiscussion(DiscussionsRepository repo)
+        {
+            InitializeComponent();
+            _repo = repo;
+
+            var discussionContext = Program.AppServices.GetRequiredService<DiscussionContext>();
+            _selectedDiscussion = discussionContext.CurrentDiscussion;
+            txtComment.Text = discussionContext.CurrentDiscussion.Comment;
+            this.FormClosed += (s, args) => Application.Exit();
+        }
+
+        private void btnLogout_Click(object sender, EventArgs e)
+        {
+            Login loginForm = Program.AppServices.GetRequiredService<Login>();
+            loginForm.Show();
+            this.Hide();
+        }
+
+        private bool ValidateInput(string comment, out string error)
+        {
+            error = string.Empty;
+
+            // Only validate non-blank fields
+            // No validation needed for title or author since their only requirement is to be non-blank
+
+            // Description cannot be longer than 1024 characters
+            if (!string.IsNullOrEmpty(comment))
+            {
+                if (comment.Length > 2048)
+                {
+                    error = "Description cannot be longer than 2048 characters.";
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void btnSaveChanges_Click(object sender, EventArgs e)
+        {
+            if (!ValidateInput(txtComment.Text, out string error))
+            {
+                MessageBox.Show(error, "Input Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            DiscussionUpdateDTO dto = new DiscussionUpdateDTO
+            {
+                Comment = txtComment.Text
+            };
+
+            var result = _repo.Update(_selectedDiscussion.Id, dto);
+            if (!result)
+            {
+                MessageBox.Show("No changes found");
+            }
+
+            DiscussionBoard discussionBoard = Program.AppServices.GetRequiredService<DiscussionBoard>();
+            discussionBoard.Show();
+            this.Hide();
+        }
+
+        private void btnBack_Click(object sender, EventArgs e)
+        {
+            DiscussionBoard discussionBoard = Program.AppServices.GetRequiredService<DiscussionBoard>();
+            discussionBoard.Show();
+            this.Hide();
+        }
+    }
+}

--- a/BookClub/Forms/EditDiscussion.resx
+++ b/BookClub/Forms/EditDiscussion.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/BookClub/Models/Discussion.cs
+++ b/BookClub/Models/Discussion.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.Contracts;
 
 namespace BookClub.Models;
 
@@ -32,4 +33,16 @@ public class Discussion
     }
 
     public Discussion() { }
+}
+
+public class DiscussionUpdateDTO
+{
+    [Required]
+    [StringLength(2048, ErrorMessage = "Comment cannot be longer than 2048 characters.")]
+    public string? Comment { get; set; } = string.Empty;
+    public DiscussionUpdateDTO(string comment)
+    {
+        Comment = comment;
+    }
+    public DiscussionUpdateDTO() { }
 }

--- a/BookClub/Program.cs
+++ b/BookClub/Program.cs
@@ -50,6 +50,7 @@ internal static class Program
 
                 // Discussion board form
                 services.AddTransient<DiscussionBoard>();
+                services.AddTransient<EditDiscussion>();
 
                 // Register repositories
                 services.AddScoped<AccountsRepository>();
@@ -57,11 +58,14 @@ internal static class Program
                 services.AddScoped<ReviewsRepository>();
                 services.AddScoped<DiscussionsRepository>();
 
-                // Register current user (stores account Id)
+                // Register current user (stores account object)
                 services.AddSingleton<UserContext>();
 
-                // Register current book (stores book Id)
+                // Register current book (stores book object)
                 services.AddSingleton<BookContext>();
+
+                // Register current discussion (stores discussion object)
+                services.AddSingleton<DiscussionContext>();
 
             })
             .Build();

--- a/BookClub/Repositories/DiscussionsRepository.cs
+++ b/BookClub/Repositories/DiscussionsRepository.cs
@@ -53,27 +53,26 @@ public class DiscussionsRepository
      *  UPDATE Operations 
      */
 
-    //public bool Update(int id, ReviewUpdateDTO dto)
-    //{
-    //    var validationContext = new ValidationContext(dto);
-    //    var validationResults = new List<ValidationResult>();
+    public bool Update(int id, DiscussionUpdateDTO dto)
+    {
+        var validationContext = new ValidationContext(dto);
+        var validationResults = new List<ValidationResult>();
 
-    //    bool isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
+        bool isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
 
-    //    if (!isValid)
-    //    {
-    //        // Validation failed; optionally log errors or handle as needed
-    //        return false;
-    //    }
+        if (!isValid)
+        {
+            // Validation failed; optionally log errors or handle as needed
+            return false;
+        }
 
-    //    var discussion = _context.Reviews.Find(id);
-    //    if (discussion == null) return false;
+        var discussion = _context.Discussions.Find(id);
+        if (discussion == null) return false;
 
-    //    discussion.Rating = dto.Rating ?? discussion.Rating;
-    //    discussion.Comment = dto.Comment ?? review.Comment;
+        discussion.Comment = dto.Comment ?? discussion.Comment;
 
-    //    return _context.SaveChanges() > 0;
-    //}
+        return _context.SaveChanges() > 0;
+    }
 
     /*
      *  DELETE Operations 

--- a/BookClub/Resources/DiscussionContext.cs
+++ b/BookClub/Resources/DiscussionContext.cs
@@ -1,0 +1,8 @@
+﻿using BookClub.Models;
+
+namespace BookClub.Resources;
+
+public class DiscussionContext
+{
+    public Discussion? CurrentDiscussion { get; set; }
+}


### PR DESCRIPTION
Closes #153 

This pull request introduces the ability to edit discussion comments in the BookClub application. It adds a new `EditDiscussion` form that enables users to update the content of a discussion comment, including validation and persistence of changes. The implementation includes UI, data transfer objects, repository logic, and dependency injection updates.

**Feature: Edit Discussion Comments**

* Added a new `EditDiscussion` form with UI elements for editing a discussion comment, saving changes, navigating back, and logging out (`EditDiscussion.Designer.cs`, `EditDiscussion.cs`, `EditDiscussion.resx`). [[1]](diffhunk://#diff-f2dbb93fab18b0b254436fe93deb68f75ece096e5fae9da53e0728c0b5e3e677R1-R102) [[2]](diffhunk://#diff-d609cdf16015b726e6c54e3fa2dbba7b00b1a18555dcf0dbb06488fc35cf1b31R1-R82) [[3]](diffhunk://#diff-5021d5e0fe40aa71438bccaed1a28c7b073586b980486ae3053fa88c5817d693R1-R120)
* Implemented logic to open the `EditDiscussion` form from the discussion board, passing the selected discussion for editing (`DiscussionBoard.cs`).
* Introduced the `DiscussionUpdateDTO` class for validating and transferring updated comment data (`Discussion.cs`).
* Updated the `DiscussionsRepository` to support updating a discussion comment with validation (`DiscussionsRepository.cs`).

**Infrastructure and Dependency Injection**

* Registered the new `EditDiscussion` form and `DiscussionContext` for dependency injection, enabling context sharing and form navigation (`Program.cs`, `DiscussionContext.cs`). [[1]](diffhunk://#diff-c0178c2f07e53338beaa27c3179383e2b69cc5be55e3ee3183e3317f060b3d79R53-R69) [[2]](diffhunk://#diff-0ec95979e0ed913a7eb826abfe129a7b7bb9726c660f9c3628cbb77ac2f4accfR1-R8)