### PR TITLE
Issue#158 Add Navigation to EditReview Form

### DIFF
--- a/BookClub/Forms/EditReview.Designer.cs
+++ b/BookClub/Forms/EditReview.Designer.cs
@@ -138,6 +138,7 @@
             btnDeleteReview.TabIndex = 26;
             btnDeleteReview.Text = "Delete Review";
             btnDeleteReview.UseVisualStyleBackColor = true;
+            btnDeleteReview.Click += new System.EventHandler(this.btnDeleteReview_Click);
             // 
             // EditReview
             // 

--- a/BookClub/Forms/Reviews.Designer.cs
+++ b/BookClub/Forms/Reviews.Designer.cs
@@ -223,6 +223,7 @@ partial class Reviews
         btnEditReview.TabIndex = 21;
         btnEditReview.Text = "Edit";
         btnEditReview.UseVisualStyleBackColor = true;
+        btnEditReview.Click += new System.EventHandler(this.btnEditReview_Click);
         // 
         // btnDeleteReview
         // 
@@ -232,6 +233,7 @@ partial class Reviews
         btnDeleteReview.TabIndex = 22;
         btnDeleteReview.Text = "Delete";
         btnDeleteReview.UseVisualStyleBackColor = true;
+        btnDeleteReview.Click += btnDeleteReview_Click;
         // 
         // Reviews
         // 

--- a/BookClub/Forms/Reviews.Designer.cs
+++ b/BookClub/Forms/Reviews.Designer.cs
@@ -45,6 +45,8 @@ partial class Reviews
         pcbStar4 = new PictureBox();
         pcbStar1 = new PictureBox();
         pcbStar5 = new PictureBox();
+        btnEditReview = new Button();
+        btnDeleteReview = new Button();
         ((System.ComponentModel.ISupportInitialize)pcbBookThumbnail).BeginInit();
         ((System.ComponentModel.ISupportInitialize)pcbStar3).BeginInit();
         ((System.ComponentModel.ISupportInitialize)pcbStar2).BeginInit();
@@ -213,11 +215,31 @@ partial class Reviews
         pcbStar5.TabIndex = 18;
         pcbStar5.TabStop = false;
         // 
+        // btnEditReview
+        // 
+        btnEditReview.Location = new Point(264, 409);
+        btnEditReview.Name = "btnEditReview";
+        btnEditReview.Size = new Size(129, 29);
+        btnEditReview.TabIndex = 21;
+        btnEditReview.Text = "Edit";
+        btnEditReview.UseVisualStyleBackColor = true;
+        // 
+        // btnDeleteReview
+        // 
+        btnDeleteReview.Location = new Point(534, 409);
+        btnDeleteReview.Name = "btnDeleteReview";
+        btnDeleteReview.Size = new Size(129, 29);
+        btnDeleteReview.TabIndex = 22;
+        btnDeleteReview.Text = "Delete";
+        btnDeleteReview.UseVisualStyleBackColor = true;
+        // 
         // Reviews
         // 
         AutoScaleDimensions = new SizeF(8F, 20F);
         AutoScaleMode = AutoScaleMode.Font;
         ClientSize = new Size(800, 450);
+        Controls.Add(btnDeleteReview);
+        Controls.Add(btnEditReview);
         Controls.Add(pcbStar5);
         Controls.Add(pcbStar1);
         Controls.Add(pcbStar4);
@@ -266,4 +288,6 @@ partial class Reviews
     private PictureBox pcbStar4;
     private PictureBox pcbStar1;
     private PictureBox pcbStar5;
+    private Button btnEditReview;
+    private Button btnDeleteReview;
 }

--- a/BookClub/Program.cs
+++ b/BookClub/Program.cs
@@ -47,6 +47,7 @@ internal static class Program
 
                 // Review related forms
                 services.AddTransient<Reviews>();
+                services.AddTransient<EditReview>();
 
                 // Discussion board form
                 services.AddTransient<DiscussionBoard>();
@@ -66,6 +67,9 @@ internal static class Program
 
                 // Register current discussion (stores discussion object)
                 services.AddSingleton<DiscussionContext>();
+
+                // Register current review (stores review object)
+                services.AddSingleton<ReviewContext>();
 
             })
             .Build();

--- a/BookClub/Resources/ReviewContext.cs
+++ b/BookClub/Resources/ReviewContext.cs
@@ -1,0 +1,8 @@
+﻿using BookClub.Models;
+
+namespace BookClub.Resources;
+
+public class ReviewContext
+{
+    public Review? CurrentReview { get; set; }
+}


### PR DESCRIPTION
This pull request adds the ability for users to edit and delete their reviews directly from the `Reviews` form. It introduces a shared `ReviewContext` for managing the currently selected review, enables selection of reviews in the UI, and connects the `EditReview` form to the main review list. Additionally, it improves the user experience by enabling/disabling action buttons based on selection and provides feedback for update and delete operations.

**New review selection and editing workflow:**

- Added `ReviewContext` as a singleton service to store the currently selected review, allowing seamless data sharing between the `Reviews` and `EditReview` forms. (`BookClub/Resources/ReviewContext.cs`, `BookClub/Program.cs`) [[1]](diffhunk://#diff-21e58968204230c413cb29125e5692ac6759f3a403478b29170357df5a650d0dR1-R8) [[2]](diffhunk://#diff-c0178c2f07e53338beaa27c3179383e2b69cc5be55e3ee3183e3317f060b3d79R71-R73)
- Made reviews in the `Reviews` form selectable; users can now select their own review, which highlights the selection and enables the Edit/Delete buttons. (`BookClub/Forms/Reviews.cs`) [[1]](diffhunk://#diff-d145d40228d6b42e28a635aaf62703fb0ce77c38ba75f39ddb8c52d0650cd8a8R21-R23) [[2]](diffhunk://#diff-d145d40228d6b42e28a635aaf62703fb0ce77c38ba75f39ddb8c52d0650cd8a8R47-R61) [[3]](diffhunk://#diff-d145d40228d6b42e28a635aaf62703fb0ce77c38ba75f39ddb8c52d0650cd8a8R179-R257)

**Edit and delete functionality:**

- Added Edit and Delete buttons to the `Reviews` form, with handlers that open the `EditReview` form or delete the selected review, respectively. (`BookClub/Forms/Reviews.Designer.cs`, `BookClub/Forms/Reviews.cs`) [[1]](diffhunk://#diff-9cbaf133fe1d561dc17c0d40586538d11223238a32cc618f678548e1543f8bf3R48-R49) [[2]](diffhunk://#diff-9cbaf133fe1d561dc17c0d40586538d11223238a32cc618f678548e1543f8bf3R218-R244) [[3]](diffhunk://#diff-9cbaf133fe1d561dc17c0d40586538d11223238a32cc618f678548e1543f8bf3R293-R294) [[4]](diffhunk://#diff-d145d40228d6b42e28a635aaf62703fb0ce77c38ba75f39ddb8c52d0650cd8a8R179-R257)
- Refactored `EditReview` to use `ReviewContext` for loading the selected review, and updated logic to always set both comment and rating when updating, with improved feedback for success/failure. (`BookClub/Forms/EditReview.cs`) [[1]](diffhunk://#diff-f467b0813f4299863d1e1f6f83ab0dd848e56f7092d7fe946a32d702856b5f4fR13-R40) [[2]](diffhunk://#diff-f467b0813f4299863d1e1f6f83ab0dd848e56f7092d7fe946a32d702856b5f4fL75-R107) [[3]](diffhunk://#diff-f467b0813f4299863d1e1f6f83ab0dd848e56f7092d7fe946a32d702856b5f4fL134-R134)
- Added event handler for the Delete Review button in the `EditReview` form. (`BookClub/Forms/EditReview.Designer.cs`)

**Dependency injection and form management:**

- Registered `EditReview` as a transient service for DI, ensuring proper instantiation and navigation between forms. (`BookClub/Program.cs`)
- Ensured that after editing or deleting a review, the reviews panel refreshes and the selection/action buttons are reset. (`BookClub/Forms/Reviews.cs`)

These changes collectively provide a more interactive and user-friendly review management experience.

Closes #158 